### PR TITLE
URLtokenのチェックメソッドを追加した

### DIFF
--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -51,6 +51,12 @@ class EventsController < ApplicationController
       end
     end
 
+    def show_with_token
+      event = Event.find_by(url_token: params[:url_token])
+      return render_fault("存在しないイベントです") if event.nil?
+      render :json => event
+    end
+
     def next
       event = Event.find_by(id: params[:id])
       if event != nil && check_admin_has_event(event)

--- a/quiz_server/config/routes.rb
+++ b/quiz_server/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   #patch 'admin_users' => 'admin_users#update'
+  get 'events/show_with_token/:url_token' => 'events#show_with_token'
   get 'events/start/:id' => 'events#start'
   get 'events/close/:id' => 'events#close'
   delete 'events/clear/:id' => 'events#clear'


### PR DESCRIPTION
やったこと
・既に実装ずみの発行されたurltokenからイベントを特定し、それを返すメソッドを追加
・イベントに参加する/user/login/:idのページにアクセスする際に、このメソッドを叩いてもらう。（クライアントサイドは未実装）
