### PR TITLE
暫定対応

### DIFF
--- a/quiz_server/app/controllers/answerers_controller.rb
+++ b/quiz_server/app/controllers/answerers_controller.rb
@@ -15,7 +15,7 @@ class AnswerersController < ApplicationController
         answerer = event.answerers.create(name: params[:name])
         #ユーザートークンの発行
         user_token = SecureRandom.uuid
-        answerer.update_attributes(:user_token => user_token)
+        answerer.update_attributes(:user_token => user_token, :rank => -1)
         set_user_token_cookie(user_token)
         render_success("ユーザーの作成に成功しました")
     end

--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_action :check_admin_user_exist
+  before_action :check_admin_user_exist, except: :show_with_token
 
     def index
         events = Event.where(admin_user_id: current_admin_user.id)


### PR DESCRIPTION
やったこと
・解答者のランクの初期値を設定した
→【恒久対応】answerごとではなくanswererごとにランクつけする

・イベントコントローラーでの事前処理で解答者のアクセスが弾かれるのでexcept:で例外を追加した
→【恒久対応】そもそもroleが違うのにコントローラーが同じなのはおかしいので分ける
