### PR TITLE
解答者の回答情報までJSONで返すようにした

### DIFF
--- a/quiz_server/app/controllers/answerers_controller.rb
+++ b/quiz_server/app/controllers/answerers_controller.rb
@@ -21,7 +21,9 @@ class AnswerersController < ApplicationController
     end
 
     def show
-        render :json => @user
+        render :json => { :user => @user,
+                          :answers => @user.answers
+                      }
     end
 
     def get_event

--- a/quiz_server/app/controllers/answerers_controller.rb
+++ b/quiz_server/app/controllers/answerers_controller.rb
@@ -22,7 +22,8 @@ class AnswerersController < ApplicationController
 
     def show
         render :json => { :user => @user,
-                          :answers => @user.answers
+                          :answers => @user.answers,
+                          :questions => @user.event.questions
                       }
     end
 


### PR DESCRIPTION
【注意】
※既存のコードに手を加えているので、こいつをマージされると、クライアント側で改修が必要になると思います。（階層が一つ深くなるので、今date.rankとかやっているところがdata.user.rankとかになるのかな？）

【やったこと】
/api/answerers/scoreで
answerersのテーブルの中身しか返していなかったので加えて
①answerersに紐づく、answersの情報
②そのanswerersが参加していたeventのquestionsを返すことにした

https://github.com/haijima/quiz/pull/83
こちらのプルリクで平均回答時間がとれるのでこれにより

・順位
・平均回答時間（正解した場合の）
・正答数（X問/Y問中）
・何問目で何を選択し、正誤、正解は何番だったか

上記のような値がとれるようになります。
