### PR TITLE
イベントのTOKENをオンラインで発行できるようにした

### DIFF
--- a/quiz_server/app/controllers/application_controller.rb
+++ b/quiz_server/app/controllers/application_controller.rb
@@ -11,6 +11,11 @@ class ApplicationController < ActionController::Base
   # => トークンによる認証
   before_action      :authenticate_user_from_token!, if: -> {params[:email].present?}
 
+  # 例外ハンドル
+  rescue_from Exception,                        with: :handle_500
+  rescue_from ActiveRecord::RecordNotFound,     with: :handle_404
+  rescue_from ActionController::RoutingError,   with: :handle_404
+
   #　パラメータからtokenを取得するメソッド
   def get_token_from_response
     params[:authenticity_token] = form_authenticity_token

--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -129,6 +129,13 @@ class EventsController < ApplicationController
         end
     end
 
+    def set_url
+        event = Event.find_by(id: params[:id])
+        url_token = SecureRandom.urlsafe_base64
+        event.update(url_token:url_token)
+        render :json => event
+    end
+
     private
 
     def check_admin_user_exist

--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -129,10 +129,10 @@ class EventsController < ApplicationController
         end
     end
 
-    def set_url
+    def set_url_token
         event = Event.find_by(id: params[:id])
         return render_fault("存在しないイベントです") if event.nil?
-        event.set_url
+        event.set_url_token
         render :json => event
     end
 

--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -131,6 +131,7 @@ class EventsController < ApplicationController
 
     def set_url
         event = Event.find_by(id: params[:id])
+        return render_fault("存在しないイベントです") if event.nil?
         url_token = SecureRandom.urlsafe_base64
         event.update(url_token:url_token)
         render :json => event

--- a/quiz_server/app/controllers/events_controller.rb
+++ b/quiz_server/app/controllers/events_controller.rb
@@ -132,8 +132,7 @@ class EventsController < ApplicationController
     def set_url
         event = Event.find_by(id: params[:id])
         return render_fault("存在しないイベントです") if event.nil?
-        url_token = SecureRandom.urlsafe_base64
-        event.update(url_token:url_token)
+        event.set_url
         render :json => event
     end
 

--- a/quiz_server/app/controllers/payments_controller.rb
+++ b/quiz_server/app/controllers/payments_controller.rb
@@ -21,9 +21,13 @@ respond_to :json
         )
 
         #イベントにURL_TOKENをセット
-        event.set_url_token
+        token = event.set_url_token
 
-        render_sccess("支払いが完了しました")
+        render :json => { :success => true,
+                          :info => "決済処理が完了しました",
+                          :url_token => token
+                        }
+
         rescue WebPay::ErrorResponse::CardError => e
         # エラーハンドリング。発生する例外の種類がいくつか用意されているので、内容に応じて処理を書く
         render_fault("パラメータが不正です")

--- a/quiz_server/app/controllers/payments_controller.rb
+++ b/quiz_server/app/controllers/payments_controller.rb
@@ -20,17 +20,12 @@ respond_to :json
             customer: customer.id
         )
 
-        set_url_to_event(event)
+        #イベントにURL_TOKENをセット
+        event.set_url
 
         render_sccess("支払いが完了しました")
         rescue WebPay::ErrorResponse::CardError => e
         # エラーハンドリング。発生する例外の種類がいくつか用意されているので、内容に応じて処理を書く
         render_fault("パラメータが不正です")
-    end
-
-    def set_url_to_event(event)
-        #url = root_url(:only_path => false) + "answers/new/"
-        url_token = SecureRandom.urlsafe_base64
-        event.update(url_token:url_token)
     end
 end

--- a/quiz_server/app/controllers/payments_controller.rb
+++ b/quiz_server/app/controllers/payments_controller.rb
@@ -21,7 +21,7 @@ respond_to :json
         )
 
         #イベントにURL_TOKENをセット
-        event.set_url
+        event.set_url_token
 
         render_sccess("支払いが完了しました")
         rescue WebPay::ErrorResponse::CardError => e

--- a/quiz_server/app/models/event.rb
+++ b/quiz_server/app/models/event.rb
@@ -11,4 +11,12 @@ class Event < ActiveRecord::Base
       url_token = SecureRandom.urlsafe_base64
       self.update(url_token:url_token)
     end
+
+    def is_free_plan?
+        self.course_id == 1
+    end
+
+    def is_paid?
+        self.url_token != ""
+    end
 end

--- a/quiz_server/app/models/event.rb
+++ b/quiz_server/app/models/event.rb
@@ -6,4 +6,9 @@ class Event < ActiveRecord::Base
     belongs_to :admin_user
 
     default_scope ->{where(is_delete: false)}
+
+    def set_url
+      url_token = SecureRandom.urlsafe_base64
+      self.update(url_token:url_token)
+    end
 end

--- a/quiz_server/app/models/event.rb
+++ b/quiz_server/app/models/event.rb
@@ -7,7 +7,7 @@ class Event < ActiveRecord::Base
 
     default_scope ->{where(is_delete: false)}
 
-    def set_url
+    def set_url_token
       url_token = SecureRandom.urlsafe_base64
       self.update(url_token:url_token)
     end

--- a/quiz_server/config/routes.rb
+++ b/quiz_server/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  get 'events/set_url/:id' => 'events#set_url'
+  get 'events/set_url_token/:id' => 'events#set_url_token'
   get 'events/show_with_token/:url_token' => 'events#show_with_token'
   get 'events/start/:id' => 'events#start'
   get 'events/close/:id' => 'events#close'

--- a/quiz_server/config/routes.rb
+++ b/quiz_server/config/routes.rb
@@ -1,20 +1,27 @@
 Rails.application.routes.draw do
-  #patch 'admin_users' => 'admin_users#update'
+
+  get 'events/set_url/:id' => 'events#set_url'
   get 'events/show_with_token/:url_token' => 'events#show_with_token'
   get 'events/start/:id' => 'events#start'
   get 'events/close/:id' => 'events#close'
   delete 'events/clear/:id' => 'events#clear'
   get 'events/next/:id' => 'events#next'
   resources :events, only: [:index, :show, :create, :destroy, :update]
+
   get 'choices/:id/is_correct' => 'choices#is_correct'
   resources :choices, only: [:index, :show, :destroy]
+
   resources :payments, only: [:create]
+
+  resources :questions, only: [:index, :show, :create, :destroy, :update]
+
   get 'answerers/get_question' => 'answerers#get_question'
   get 'answerers/get_event/:url_token' => 'answerers#get_event'
-  resources :questions, only: [:index, :show, :create, :destroy, :update]
   get 'answerers/score' => 'answerers#show'
   resources :answerers, only: [:index, :create, :show]
+
   resources :answers, only: [:index, :show, :update, :create]
+
   resources :courses, only: [:index, :show]
 
   devise_for :admin_users, controllers: { sessions: "session",


### PR DESCRIPTION
【やったこと】
いままで決済完了時にしか、イベントにtokenを発行していなかったのに対して、オンラインからでも発行できるようにした。

eventsのmodelにメソッドをset_url_tokenというメソッドを持たせて、
event_controlller も payment_controller もそこを参照するような作りに変更した

また、ルーティングが変更するにあたり、routes.rbが見にくかったので改行を加えた（本当はもっときれいにしたい）
